### PR TITLE
Match card and Match details page skeleton

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import TournamentManager from "./pages/TournamentManager";
 import TournamentSchedule from "./pages/TournamentSchedule";
 import TournamentTeam from "./pages/TournamentTeam";
 import TournamentStandings from "./pages/TournamentStandings";
+import MatchDetails from "./pages/MatchDetails";
 
 function App() {
   return (
@@ -27,8 +28,8 @@ function App() {
         <Route path="/tournament/:slug" component={Tournament} />
         <Route path="/tournament/:slug/schedule" component={TournamentSchedule} />
         <Route path="/tournament/:slug/standings" component={TournamentStandings} />
-        {/* <Route path="/tournament/:slug/standings" component={Tournament} />
-        <Route path="/tournament/:slug/rules" component={Tournament} /> */}
+        <Route path="/tournament/:tournament_slug/schedule/match/:match_id" component={MatchDetails}/>
+        {/* <Route path="/tournament/:slug/rules" component={Tournament} /> */}
         <Route path="/tournament/:tournament_slug/team/:team_slug" component={TournamentTeam} />
         {/* Authenticated routes */}
         {/* <AuthenticatedRoute path="/tournament-manager" component={TournamentManager} /> */}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -4,7 +4,7 @@ export default function Layout(props) {
   return (
     <div class="flex min-h-screen flex-col">
       <Header />
-      <main class="flex-1">{props.children}</main>
+      <main class="flex-1 mx-2">{props.children}</main>
       <footer class="bg-background py-6 text-center text-sm text-muted-foreground">
         <div class="container">
           <p>

--- a/frontend/src/components/match/MatchCard.jsx
+++ b/frontend/src/components/match/MatchCard.jsx
@@ -1,20 +1,26 @@
 import { A } from "@solidjs/router";
 import { useQuery } from "@tanstack/solid-query";
-import { queryClient } from "../../lib/queryClient";
+// import { queryClient } from "../../lib/queryClient";
 import { clsx } from "clsx";
 import { Icon } from "solid-heroicons";
-import { arrowRight, chevronRight, pencil, play } from "solid-heroicons/solid";
+// import { arrowRight, chevronRight, pencil, play } from "solid-heroicons/solid";
+import { clock, mapPin } from "solid-heroicons/outline";
+
 import { createEffect, createSignal, Match, Show, Switch } from "solid-js";
 
-import {
-  matchCardColorToButtonStyles,
-  matchCardColorToRingColorMap
-} from "../../colors";
+// import {
+//   matchCardColorToButtonStyles,
+//   matchCardColorToRingColorMap
+// } from "../../colors";
+
 import { fetchUserPermissionsForMatch } from "~/queries";
-import { getMatchCardColor } from "./utils";
-import MatchScoreForm from "./MatchScoreForm";
+// import { getMatchCardColor } from "./utils";
+// import MatchScoreForm from "./MatchScoreForm";
 import MatchHeader from "./MatchHeader";
-import SubmitScore from "./SubmitScore";
+// import SubmitScore from "./SubmitScore";
+import { Separator } from "../ui/separator";
+// import { Button, buttonVariants } from "../ui/button";
+
 // import MatchSpiritScoreForm from "./MatchSpiritScoreForm";
 // import SpiritScoreTable from "./SpiritScoreTable";
 // import FinalSpiritScores from "./FinalSpiritScores";
@@ -102,14 +108,6 @@ const TournamentMatch = props => {
     );
   };
 
-  createEffect(() => {
-    if (userAccessQuery.isSuccess) {
-      console.log(userAccessQuery.data?.admin_team_ids)
-      console.log(props.match["team_1"].name, props.match["team_2"].name, isMatchTeamAdmin())
-      console.log(hasUserNotSubmittedScores())
-    }
-  })
-
   const hasUserNotSubmittedScores = () => {
     return (
       (isTeamAdminOf(props.match["team_1"].id) &&
@@ -146,196 +144,271 @@ const TournamentMatch = props => {
   };
 
   return (
-    <>
-      <div class="mb-4">
-        <MatchHeader
-          match={props.match}
-          dontMinimiseMatchName
-          matchCardColorOverride={props.matchCardColorOverride}
-        />
-      </div>
-      <div class="flex justify-center text-sm">
-        <Show
-          when={props.match[`team_${currTeamNo()}`]}
-          fallback={
-            <span class="w-1/3 text-center font-bold">
-              {props.match[`placeholder_seed_${currTeamNo()}`]}
-            </span>
-          }
-        >
-          <img
-            class={clsx(
-              "mr-1 inline-block h-6 w-6 rounded-full p-1 ring-2",
-              props.imgRingColor
-                ? matchCardColorToRingColorMap[props.imgRingColor]
-                : matchCardColorToRingColorMap[getMatchCardColor(props.match)]
-            )}
-            src={getTeamImage(props.match[`team_${currTeamNo()}`])}
-            alt="Bordered avatar"
-          />
-          <span class="w-1/3 text-center font-bold text-gray-600 dark:text-gray-300">
-            <Show
-              when={props.bothTeamsClickable}
-              fallback={`${props.match[`team_${currTeamNo()}`].name} (${
-                props.match[`placeholder_seed_${currTeamNo()}`]
-              })`}
-            >
-              <A
-                href={`/tournament/${props.tournamentSlug}/team/${
-                  props.match[`team_${currTeamNo()}`].slug
-                }`}
+    <A href={`./match/${props.match?.id}`}>
+      <div class="px-1">
+        <div class="mb-4 inline-flex w-full justify-between gap-2">
+          <span class="w-full">
+            <MatchHeader
+              match={props.match}
+              dontMinimiseMatchName
+              matchCardColorOverride={props.matchCardColorOverride}
+            />
+          </span>
+        </div>
+
+        <div class="flex flex-col gap-4 px-1">
+          {/* Team 1 */}
+          <div class="flex w-full items-center justify-between text-base">
+            <div>
+              <Show
+                when={props.match[`team_${currTeamNo()}`]}
+                fallback={
+                  <span class="w-1/3 text-center font-bold">
+                    {props.match[`placeholder_seed_${currTeamNo()}`]}
+                  </span>
+                }
               >
-                {`${props.match[`team_${currTeamNo()}`].name} (${
-                  props.match[`placeholder_seed_${currTeamNo()}`]
-                })`}
-              </A>
-            </Show>
-          </span>
-        </Show>
-
-        <span class="mx-2">VS</span>
-        <Show
-          when={props.match[`team_${oppTeamNo()}`]}
-          fallback={
-            <span class="w-1/3 text-center font-bold">
-              {props.match[`placeholder_seed_${oppTeamNo()}`]}
+                <img
+                  class={clsx(
+                    "mr-2 inline-block h-6 w-6 rounded-full object-cover p-1 ring-1 ring-gray-400"
+                    // props.imgRingColor
+                    //   ? matchCardColorToRingColorMap[props.imgRingColor]
+                    //   : matchCardColorToRingColorMap[
+                    //       getMatchCardColor(props.match)
+                    //     ]
+                  )}
+                  src={getTeamImage(props.match[`team_${currTeamNo()}`])}
+                  alt="Bordered avatar"
+                />
+                <span class="w-1/3 text-center font-bold text-gray-600 dark:text-gray-300">
+                  <Show
+                    when={props.bothTeamsClickable}
+                    fallback={`${props.match[`team_${currTeamNo()}`].name} (${
+                      props.match[`placeholder_seed_${currTeamNo()}`]
+                    })`}
+                  >
+                    <A
+                      href={`/tournament/${props.tournamentSlug}/team/${
+                        props.match[`team_${currTeamNo()}`].slug
+                      }`}
+                    >
+                      {`${props.match[`team_${currTeamNo()}`].name} (${
+                        props.match[`placeholder_seed_${currTeamNo()}`]
+                      })`}
+                    </A>
+                  </Show>
+                </span>
+              </Show>
+            </div>
+            <div class="text-base font-bold">
+              <Show when={props.match.status === "completed"}>
+                <Switch>
+                  <Match
+                    when={
+                      props.match[`score_team_${currTeamNo()}`] >
+                      props.match[`score_team_${oppTeamNo()}`]
+                    }
+                  >
+                    <span class="text-green-500">
+                      {props.match[`score_team_${currTeamNo()}`]}
+                    </span>
+                  </Match>
+                  <Match
+                    when={
+                      props.match[`score_team_${currTeamNo()}`] <
+                      props.match[`score_team_${oppTeamNo()}`]
+                    }
+                  >
+                    <span class="text-red-500">
+                      {props.match[`score_team_${currTeamNo()}`]}
+                    </span>
+                  </Match>
+                  <Match
+                    when={
+                      props.match[`score_team_${currTeamNo()}`] ===
+                      props.match[`score_team_${oppTeamNo()}`]
+                    }
+                  >
+                    <span class="text-blue-500">
+                      {props.match[`score_team_${currTeamNo()}`]}
+                    </span>
+                  </Match>
+                </Switch>
+              </Show>
+            </div>
+          </div>
+          {/* Team 2 */}
+          <div class="flex w-full items-center justify-between text-base">
+            <div>
+              <Show
+                when={props.match[`team_${oppTeamNo()}`]}
+                fallback={
+                  <span class="w-1/3 text-center font-bold">
+                    {props.match[`placeholder_seed_${oppTeamNo()}`]}
+                  </span>
+                }
+              >
+                <img
+                  class={clsx(
+                    "mr-2 inline-block h-6 w-6 rounded-full object-cover p-1 ring-1 ring-gray-400"
+                    // props.imgRingColor
+                    //   ? matchCardColorToRingColorMap[props.imgRingColor]
+                    //   : matchCardColorToRingColorMap[
+                    //       getMatchCardColor(props.match)
+                    //     ]
+                  )}
+                  src={getTeamImage(props.match[`team_${oppTeamNo()}`])}
+                  alt="Bordered avatar"
+                />
+                <span class="w-1/3 text-center font-bold text-gray-600 dark:text-gray-300">
+                  <Show
+                    when={props.bothTeamsClickable}
+                    fallback={`${props.match[`team_${oppTeamNo()}`].name} (${
+                      props.match[`placeholder_seed_${oppTeamNo()}`]
+                    })`}
+                  >
+                    <A
+                      href={`/tournament/${props.tournamentSlug}/team/${
+                        props.match[`team_${oppTeamNo()}`].slug
+                      }`}
+                    >
+                      {`${props.match[`team_${oppTeamNo()}`].name} (${
+                        props.match[`placeholder_seed_${oppTeamNo()}`]
+                      })`}
+                    </A>
+                  </Show>
+                </span>
+              </Show>
+            </div>
+            <div class="text-base font-bold">
+              <Show when={props.match.status === "completed"}>
+                <Switch>
+                  <Match
+                    when={
+                      props.match[`score_team_${currTeamNo()}`] >
+                      props.match[`score_team_${oppTeamNo()}`]
+                    }
+                  >
+                    <span class="text-red-500">
+                      {props.match[`score_team_${oppTeamNo()}`]}
+                    </span>
+                  </Match>
+                  <Match
+                    when={
+                      props.match[`score_team_${currTeamNo()}`] <
+                      props.match[`score_team_${oppTeamNo()}`]
+                    }
+                  >
+                    <span class="text-green-500">
+                      {props.match[`score_team_${oppTeamNo()}`]}
+                    </span>
+                  </Match>
+                  <Match
+                    when={
+                      props.match[`score_team_${currTeamNo()}`] ===
+                      props.match[`score_team_${oppTeamNo()}`]
+                    }
+                  >
+                    <span class="text-blue-500">
+                      {props.match[`score_team_${oppTeamNo()}`]}
+                    </span>
+                  </Match>
+                </Switch>
+              </Show>
+            </div>
+          </div>
+        </div>
+        
+        <Separator class="mb-2 mt-3" />
+        
+        {/* Field and duration */}
+        <div class="flex flex-col gap-y-2 px-1 ">
+          <div class="flex items-center gap-2">
+            <span class="text-gray-800">
+              <Icon path={mapPin} class="inline h-5 w-5" />
             </span>
-          }
-        >
-          <span class="w-1/3 text-center font-medium text-gray-600 dark:text-gray-300">
-            <A
-              href={`/tournament/${props.tournamentSlug}/team/${
-                props.match[`team_${oppTeamNo()}`].slug
-              }`}
-            >
-              {`${props.match[`team_${oppTeamNo()}`].name} (${
-                props.match[`placeholder_seed_${oppTeamNo()}`]
-              })`}
-            </A>
-          </span>
+            <span class="text-gray-500">{props.match.field?.name}</span>
+          </div>
+          <div class="flex items-center gap-2 ">
+            <span class="text-gray-800">
+              <Icon path={clock} class="inline h-5 w-5" />
+            </span>
+            <span class="text-gray-500">
+              {startTime()} - {endTime} | {props.match.duration_mins} mins
+            </span>
+          </div>
+        </div>
 
-          <img
-            class={clsx(
-              "mr-1 inline-block h-6 w-6 rounded-full p-1 ring-2",
-              props.imgRingColor
-                ? matchCardColorToRingColorMap[props.imgRingColor]
-                : matchCardColorToRingColorMap[getMatchCardColor(props.match)]
-            )}
-            src={getTeamImage(props.match[`team_${oppTeamNo()}`])}
-            alt="Bordered avatar"
-          />
-        </Show>
-      </div>
-
-      {/* Match score */}
-      <Show when={props.match.status === "completed"}>
-        <p class="text-center font-bold">
-          <Switch>
-            <Match
-              when={
-                props.match[`score_team_${currTeamNo()}`] >
-                props.match[`score_team_${oppTeamNo()}`]
-              }
+        <div class="mt-2 flex flex-wrap items-center justify-center gap-2">
+          {/* Watch button */}
+          {/* <Show when={props.match.video_url}>
+            <a
+              class="flex justify-center"
+              href={props.match.video_url}
+              target="_blank"
             >
-              <span class="text-green-500 dark:text-green-400">
-                {props.match[`score_team_${currTeamNo()}`]}
-              </span>
-              <span>{" - "}</span>
-              <span class="text-red-500 dark:text-red-400">
-                {props.match[`score_team_${oppTeamNo()}`]}
-              </span>
-            </Match>
-            <Match
-              when={
-                props.match[`score_team_${currTeamNo()}`] <
-                props.match[`score_team_${oppTeamNo()}`]
-              }
-            >
-              <span class="text-red-500 dark:text-red-400">
-                {props.match[`score_team_${currTeamNo()}`]}
-              </span>
-              <span>{" - "}</span>
-              <span class="text-green-500 dark:text-green-400">
-                {props.match[`score_team_${oppTeamNo()}`]}
-              </span>
-            </Match>
-            <Match
-              when={
-                props.match[`score_team_${currTeamNo()}`] ===
-                props.match[`score_team_${oppTeamNo()}`]
-              }
-            >
-              <span class="text-blue-500 dark:text-blue-400">
-                {props.match[`score_team_${currTeamNo()}`]}
-              </span>
-              <span>{" - "}</span>
-              <span class="text-blue-500 dark:text-blue-400">
-                {props.match[`score_team_${oppTeamNo()}`]}
-              </span>
-            </Match>
-          </Switch>
-        </p>
-      </Show>
-      {/* Field and duration */}
-      <p class="mt-2 text-center text-sm">
-        {props.match.field?.name +
-          " | " +
-          startTime() +
-          " - " +
-          endTime() +
-          " | " +
-          props.match.duration_mins +
-          " mins"}
-      </p>
-      <div class="mt-2 flex flex-wrap items-center justify-center gap-2">
-        {/* Watch button */}
-        {/* <Show when={props.match.video_url}>
-          <a
-            class="flex justify-center"
-            href={props.match.video_url}
-            target="_blank"
-          >
-            <button
-              type="button"
-              class={clsx(
-                "group relative inline-flex items-center justify-center overflow-hidden rounded-full p-0.5 text-xs font-medium",
-                "text-gray-900 focus:outline-none dark:text-white",
-                "transition-all duration-75 ease-in hover:scale-105"
-              )}
-            >
-              <span
+              <button
+                type="button"
                 class={clsx(
-                  "relative inline-flex items-center rounded-full px-2 py-1.5 transition-all duration-75 ease-in group-hover:shadow-lg dark:bg-gray-700",
-                  `bg-${
-                    props.buttonColor || getMatchCardColor(props.match)
-                  }-100`
+                  "group relative inline-flex items-center justify-center overflow-hidden rounded-full p-0.5 text-xs font-medium",
+                  "text-gray-900 focus:outline-none dark:text-white",
+                  "transition-all duration-75 ease-in hover:scale-105"
                 )}
               >
                 <span
                   class={clsx(
-                    "me-2 rounded-full px-2.5 py-0.5 text-white",
-                    props.buttonColor
-                      ? matchCardColorToButtonStyles[props.buttonColor]
-                      : matchCardColorToButtonStyles[
-                          getMatchCardColor(props.match)
-                        ]
+                    "relative inline-flex items-center rounded-full px-2 py-1.5 transition-all duration-75 ease-in group-hover:shadow-lg dark:bg-gray-700",
+                    `bg-${
+                      props.buttonColor || getMatchCardColor(props.match)
+                    }-100`
                   )}
                 >
-                  <Icon path={play} class="w-4" />
+                  <span
+                    class={clsx(
+                      "me-2 rounded-full px-2.5 py-0.5 text-white",
+                      props.buttonColor
+                        ? matchCardColorToButtonStyles[props.buttonColor]
+                        : matchCardColorToButtonStyles[
+                            getMatchCardColor(props.match)
+                          ]
+                    )}
+                  >
+                    <Icon path={play} class="w-4" />
+                  </span>
+                  Watch
+                  <Icon path={chevronRight} class="ml-1.5 w-4" />
                 </span>
-                Watch
-                <Icon path={chevronRight} class="ml-1.5 w-4" />
-              </span>
-            </button>
-          </a>
-        </Show> */}
+              </button>
+            </a>
+          </Show> */}
 
-        {/* Live score buttons */}
-        {/* <Show when={props.match.stats}>
-          <A
-            href={`/tournament/${props.tournamentSlug}/match/${props.match.id}/live`}
+          {/* Live score buttons */}
+          {/* <Show when={props.match.stats}>
+            <A
+              href={`/tournament/${props.tournamentSlug}/match/${props.match.id}/live`}
+            >
+              <ViewStatsButton
+                bgColor={`bg-${
+                  props.buttonColor || getMatchCardColor(props.match)
+                }-100`}
+                badgeColor={
+                  props.buttonColor
+                    ? matchCardColorToButtonStyles[props.buttonColor]
+                    : matchCardColorToButtonStyles[getMatchCardColor(props.match)]
+                }
+                textColor={props.buttonColor || getMatchCardColor(props.match)}
+                match={props.match}
+              />
+            </A>
+          </Show> */}
+          {/* Score buttons */}
+          {/* <Show
+            when={
+              props.match[`spirit_score_team_${currTeamNo()}`] &&
+              props.match[`spirit_score_team_${oppTeamNo()}`]
+            }
           >
-            <ViewStatsButton
+            <FinalSpiritScores
               bgColor={`bg-${
                 props.buttonColor || getMatchCardColor(props.match)
               }-100`}
@@ -344,231 +417,102 @@ const TournamentMatch = props => {
                   ? matchCardColorToButtonStyles[props.buttonColor]
                   : matchCardColorToButtonStyles[getMatchCardColor(props.match)]
               }
-              textColor={props.buttonColor || getMatchCardColor(props.match)}
-              match={props.match}
-            />
-          </A>
-        </Show> */}
-
-        {/* Score buttons */}
-        {/* <Show
-          when={
-            props.match[`spirit_score_team_${currTeamNo()}`] &&
-            props.match[`spirit_score_team_${oppTeamNo()}`]
-          }
-        >
-          <FinalSpiritScores
-            bgColor={`bg-${
-              props.buttonColor || getMatchCardColor(props.match)
-            }-100`}
-            badgeColor={
-              props.buttonColor
-                ? matchCardColorToButtonStyles[props.buttonColor]
-                : matchCardColorToButtonStyles[getMatchCardColor(props.match)]
-            }
-            spiritScoreText={
-              props.match[`spirit_score_team_${currTeamNo()}`].total +
-              " - " +
-              props.match[`spirit_score_team_${oppTeamNo()}`].total
-            }
-          >
-            <div class="space-y-2 py-2 pr-2 sm:pl-2 sm:pr-4">
-              <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
-                Spirit Scores
-              </h2>
-              <SpiritScoreTable
-                team_1={props.match[`team_${currTeamNo()}`]}
-                team_2={props.match[`team_${oppTeamNo()}`]}
-                spirit_score_team_1={
-                  props.match[`spirit_score_team_${currTeamNo()}`]
-                }
-                spirit_score_team_2={
-                  props.match[`spirit_score_team_${oppTeamNo()}`]
-                }
-              />
-              <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
-                Spirit Scores - Self
-              </h2>
-              <SpiritScoreTable
-                team_1={props.match[`team_${currTeamNo()}`]}
-                team_2={props.match[`team_${oppTeamNo()}`]}
-                spirit_score_team_1={
-                  props.match[`self_spirit_score_team_${currTeamNo()}`]
-                }
-                spirit_score_team_2={
-                  props.match[`self_spirit_score_team_${oppTeamNo()}`]
-                }
-              />
-              <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
-                MVPs
-              </h2>
-
-              <Switch>
-                <Match
-                  when={
-                    !props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${currTeamNo()}`].mvp_v2
+              spiritScoreText={
+                props.match[`spirit_score_team_${currTeamNo()}`].total +
+                " - " +
+                props.match[`spirit_score_team_${oppTeamNo()}`].total
+              }
+            >
+              <div class="space-y-2 py-2 pr-2 sm:pl-2 sm:pr-4">
+                <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
+                  Spirit Scores
+                </h2>
+                <SpiritScoreTable
+                  team_1={props.match[`team_${currTeamNo()}`]}
+                  team_2={props.match[`team_${oppTeamNo()}`]}
+                  spirit_score_team_1={
+                    props.match[`spirit_score_team_${currTeamNo()}`]
                   }
-                >
-                  <div class="mx-2 font-medium dark:text-white">
-                    <div>
-                      {
-                        props.match[`spirit_score_team_${currTeamNo()}`].mvp_v2
-                          ?.full_name
-                      }
-                    </div>
-                    <div class="text-sm text-gray-500 dark:text-gray-400">
-                      {props.match[`team_${currTeamNo()}`].name}
-                    </div>
-                  </div>
-                </Match>
-                <Match
-                  when={
-                    props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${currTeamNo()}`].mvp
+                  spirit_score_team_2={
+                    props.match[`spirit_score_team_${oppTeamNo()}`]
                   }
-                >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <img
-                      class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
-                      src={
-                        props.match[`spirit_score_team_${currTeamNo()}`].mvp
-                          ?.image_url
-                      }
-                      alt="Image"
-                    />
-                    <div class="font-medium dark:text-white">
-                      <div>
-                        {props.match[`spirit_score_team_${currTeamNo()}`].mvp
-                          ?.first_name +
-                          " " +
-                          props.match[`spirit_score_team_${currTeamNo()}`].mvp
-                            ?.last_name}
-                      </div>
-                      <div class="text-sm text-gray-500 dark:text-gray-400">
-                        {props.match[`team_${currTeamNo()}`].name}
-                      </div>
-                    </div>
-                  </div>
-                </Match>
-              </Switch>
-
-              <Switch>
-                <Match
-                  when={
-                    !props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${oppTeamNo()}`].mvp_v2
+                />
+                <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
+                  Spirit Scores - Self
+                </h2>
+                <SpiritScoreTable
+                  team_1={props.match[`team_${currTeamNo()}`]}
+                  team_2={props.match[`team_${oppTeamNo()}`]}
+                  spirit_score_team_1={
+                    props.match[`self_spirit_score_team_${currTeamNo()}`]
                   }
-                >
-                  <div class="mx-2 font-medium dark:text-white">
-                    <div>
-                      {
-                        props.match[`spirit_score_team_${oppTeamNo()}`].mvp_v2
-                          ?.full_name
-                      }
-                    </div>
-                    <div class="text-sm text-gray-500 dark:text-gray-400">
-                      {props.match[`team_${oppTeamNo()}`].name}
-                    </div>
-                  </div>
-                </Match>
-                <Match
-                  when={
-                    props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${oppTeamNo()}`].mvp
+                  spirit_score_team_2={
+                    props.match[`self_spirit_score_team_${oppTeamNo()}`]
                   }
-                >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <img
-                      class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
-                      src={
-                        props.match[`spirit_score_team_${oppTeamNo()}`].mvp
-                          ?.image_url
-                      }
-                      alt="Image"
-                    />
-                    <div class="font-medium dark:text-white">
-                      <div>
-                        {props.match[`spirit_score_team_${oppTeamNo()}`].mvp
-                          ?.first_name +
-                          " " +
-                          props.match[`spirit_score_team_${oppTeamNo()}`].mvp
-                            ?.last_name}
-                      </div>
-                      <div class="text-sm text-gray-500 dark:text-gray-400">
-                        {props.match[`team_${oppTeamNo()}`].name}
-                      </div>
-                    </div>
-                  </div>
-                </Match>
-              </Switch>
-
-              <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
-                MSPs
-              </h2>
-              <Switch>
-                <Match
-                  when={
-                    !props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${currTeamNo()}`].msp_v2
-                  }
-                >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <div class="font-medium dark:text-white">
+                />
+                <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
+                  MVPs
+                </h2>
+                <Switch>
+                  <Match
+                    when={
+                      !props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${currTeamNo()}`].mvp_v2
+                    }
+                  >
+                    <div class="mx-2 font-medium dark:text-white">
                       <div>
                         {
-                          props.match[`spirit_score_team_${currTeamNo()}`]
-                            .msp_v2?.full_name
+                          props.match[`spirit_score_team_${currTeamNo()}`].mvp_v2
+                            ?.full_name
                         }
                       </div>
                       <div class="text-sm text-gray-500 dark:text-gray-400">
                         {props.match[`team_${currTeamNo()}`].name}
                       </div>
                     </div>
-                  </div>
-                </Match>
-                <Match
-                  when={
-                    props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${currTeamNo()}`].msp
-                  }
-                >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <img
-                      class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
-                      src={
-                        props.match[`spirit_score_team_${currTeamNo()}`].msp
-                          ?.image_url
-                      }
-                      alt="Image"
-                    />
-                    <div class="font-medium dark:text-white">
-                      <div>
-                        {props.match[`spirit_score_team_${currTeamNo()}`].msp
-                          ?.first_name +
-                          " " +
-                          props.match[`spirit_score_team_${currTeamNo()}`].msp
-                            ?.last_name}
-                      </div>
-                      <div class="text-sm text-gray-500 dark:text-gray-400">
-                        {props.match[`team_${currTeamNo()}`].name}
+                  </Match>
+                  <Match
+                    when={
+                      props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${currTeamNo()}`].mvp
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <img
+                        class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
+                        src={
+                          props.match[`spirit_score_team_${currTeamNo()}`].mvp
+                            ?.image_url
+                        }
+                        alt="Image"
+                      />
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {props.match[`spirit_score_team_${currTeamNo()}`].mvp
+                            ?.first_name +
+                            " " +
+                            props.match[`spirit_score_team_${currTeamNo()}`].mvp
+                              ?.last_name}
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${currTeamNo()}`].name}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </Match>
-              </Switch>
-              <Switch>
-                <Match
-                  when={
-                    !props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${oppTeamNo()}`].msp_v2
-                  }
-                >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <div class="font-medium dark:text-white">
+                  </Match>
+                </Switch>
+                <Switch>
+                  <Match
+                    when={
+                      !props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${oppTeamNo()}`].mvp_v2
+                    }
+                  >
+                    <div class="mx-2 font-medium dark:text-white">
                       <div>
                         {
-                          props.match[`spirit_score_team_${oppTeamNo()}`].msp_v2
+                          props.match[`spirit_score_team_${oppTeamNo()}`].mvp_v2
                             ?.full_name
                         }
                       </div>
@@ -576,188 +520,355 @@ const TournamentMatch = props => {
                         {props.match[`team_${oppTeamNo()}`].name}
                       </div>
                     </div>
-                  </div>
-                </Match>
-                <Match
-                  when={
-                    props.useUCRegistrations &&
-                    props.match[`spirit_score_team_${oppTeamNo()}`].msp
-                  }
-                >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <img
-                      class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
-                      src={
-                        props.match[`spirit_score_team_${oppTeamNo()}`].msp
-                          ?.image_url
-                      }
-                      alt="Image"
-                    />
-                    <div class="font-medium dark:text-white">
-                      <div>
-                        {props.match[`spirit_score_team_${oppTeamNo()}`].msp
-                          ?.first_name +
-                          " " +
-                          props.match[`spirit_score_team_${oppTeamNo()}`].msp
-                            ?.last_name}
-                      </div>
-                      <div class="text-sm text-gray-500 dark:text-gray-400">
-                        {props.match[`team_${oppTeamNo()}`].name}
+                  </Match>
+                  <Match
+                    when={
+                      props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${oppTeamNo()}`].mvp
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <img
+                        class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
+                        src={
+                          props.match[`spirit_score_team_${oppTeamNo()}`].mvp
+                            ?.image_url
+                        }
+                        alt="Image"
+                      />
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {props.match[`spirit_score_team_${oppTeamNo()}`].mvp
+                            ?.first_name +
+                            " " +
+                            props.match[`spirit_score_team_${oppTeamNo()}`].mvp
+                              ?.last_name}
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${oppTeamNo()}`].name}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </Match>
-              </Switch>
-
-              <Show
-                when={
-                  props.match[`self_spirit_score_team_${currTeamNo()}`]
-                    ?.comments ||
-                  props.match[`self_spirit_score_team_${oppTeamNo()}`]?.comments
-                }
-              >
+                  </Match>
+                </Switch>
                 <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
-                  Comments
+                  MSPs
                 </h2>
+                <Switch>
+                  <Match
+                    when={
+                      !props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${currTeamNo()}`].msp_v2
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {
+                            props.match[`spirit_score_team_${currTeamNo()}`]
+                              .msp_v2?.full_name
+                          }
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${currTeamNo()}`].name}
+                        </div>
+                      </div>
+                    </div>
+                  </Match>
+                  <Match
+                    when={
+                      props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${currTeamNo()}`].msp
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <img
+                        class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
+                        src={
+                          props.match[`spirit_score_team_${currTeamNo()}`].msp
+                            ?.image_url
+                        }
+                        alt="Image"
+                      />
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {props.match[`spirit_score_team_${currTeamNo()}`].msp
+                            ?.first_name +
+                            " " +
+                            props.match[`spirit_score_team_${currTeamNo()}`].msp
+                              ?.last_name}
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${currTeamNo()}`].name}
+                        </div>
+                      </div>
+                    </div>
+                  </Match>
+                </Switch>
+                <Switch>
+                  <Match
+                    when={
+                      !props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${oppTeamNo()}`].msp_v2
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {
+                            props.match[`spirit_score_team_${oppTeamNo()}`].msp_v2
+                              ?.full_name
+                          }
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${oppTeamNo()}`].name}
+                        </div>
+                      </div>
+                    </div>
+                  </Match>
+                  <Match
+                    when={
+                      props.useUCRegistrations &&
+                      props.match[`spirit_score_team_${oppTeamNo()}`].msp
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <img
+                        class="h-10 w-10 rounded-full p-1 ring-2 ring-gray-300 dark:ring-gray-500"
+                        src={
+                          props.match[`spirit_score_team_${oppTeamNo()}`].msp
+                            ?.image_url
+                        }
+                        alt="Image"
+                      />
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {props.match[`spirit_score_team_${oppTeamNo()}`].msp
+                            ?.first_name +
+                            " " +
+                            props.match[`spirit_score_team_${oppTeamNo()}`].msp
+                              ?.last_name}
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${oppTeamNo()}`].name}
+                        </div>
+                      </div>
+                    </div>
+                  </Match>
+                </Switch>
                 <Show
                   when={
                     props.match[`self_spirit_score_team_${currTeamNo()}`]
-                      ?.comments
+                      ?.comments ||
+                    props.match[`self_spirit_score_team_${oppTeamNo()}`]?.comments
                   }
                 >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <div class="font-medium dark:text-white">
-                      <div>
-                        {
-                          props.match[`self_spirit_score_team_${currTeamNo()}`]
-                            ?.comments
-                        }
-                      </div>
-                      <div class="text-sm text-gray-500 dark:text-gray-400">
-                        {props.match[`team_${currTeamNo()}`].name}
-                      </div>
-                    </div>
-                  </div>
-                </Show>
-                <Show
-                  when={
-                    props.match[`self_spirit_score_team_${oppTeamNo()}`]
-                      ?.comments
-                  }
-                >
-                  <div class="mx-2 flex items-center space-x-4">
-                    <div class="font-medium dark:text-white">
-                      <div>
-                        {
-                          props.match[`self_spirit_score_team_${oppTeamNo()}`]
-                            ?.comments
-                        }
-                      </div>
-                      <div class="text-sm text-gray-500 dark:text-gray-400">
-                        {props.match[`team_${oppTeamNo()}`].name}
+                  <h2 class="text-center font-bold text-blue-600 dark:text-blue-500">
+                    Comments
+                  </h2>
+                  <Show
+                    when={
+                      props.match[`self_spirit_score_team_${currTeamNo()}`]
+                        ?.comments
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {
+                            props.match[`self_spirit_score_team_${currTeamNo()}`]
+                              ?.comments
+                          }
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${currTeamNo()}`].name}
+                        </div>
                       </div>
                     </div>
-                  </div>
+                  </Show>
+                  <Show
+                    when={
+                      props.match[`self_spirit_score_team_${oppTeamNo()}`]
+                        ?.comments
+                    }
+                  >
+                    <div class="mx-2 flex items-center space-x-4">
+                      <div class="font-medium dark:text-white">
+                        <div>
+                          {
+                            props.match[`self_spirit_score_team_${oppTeamNo()}`]
+                              ?.comments
+                          }
+                        </div>
+                        <div class="text-sm text-gray-500 dark:text-gray-400">
+                          {props.match[`team_${oppTeamNo()}`].name}
+                        </div>
+                      </div>
+                    </div>
+                  </Show>
                 </Show>
-              </Show>
-            </div>
-          </FinalSpiritScores>
-        </Show> */}
-      </div>
-
-      {/*Team Admin Actions*/}
-
-      <Show
-        when={
-          props.match.status === "scheduled" &&
-          (isMatchTeamAdmin() || isStaff())
-        }
-      >
-        <div class="inline-flex w-full items-center justify-center">
-          <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
-          <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
-            Match Scores
-          </span>
+              </div>
+            </FinalSpiritScores>
+          </Show> */}
         </div>
-        <div class="flex flex-wrap justify-center">
-          <Show
-            when={checkIfSuggestedScoresClash(
-              props.match["suggested_score_team_1"],
-              props.match["suggested_score_team_2"]
-            )}
-          >
-            <p class="mb-3 mr-2 rounded bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900 dark:text-red-300">
-              Scores Clashing
-            </p>
-          </Show>
-          <Show when={props.match[`suggested_score_team_${currTeamNo()}`]}>
-            <p class="mb-2 w-full text-center text-sm">
-              {
-                props.match[`suggested_score_team_${currTeamNo()}`][
-                  "entered_by"
-                ]["user_first_name"]
+        {/*Team Admin Actions*/}
+        {/* <Show
+          when={
+            props.match.status === "scheduled" &&
+            (isMatchTeamAdmin() || isStaff())
+          }
+        >
+          <div class="inline-flex w-full items-center justify-center">
+            <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
+            <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
+              Match Scores
+            </span>
+          </div>
+          <div class="flex flex-wrap justify-center">
+            <Show
+              when={checkIfSuggestedScoresClash(
+                props.match["suggested_score_team_1"],
+                props.match["suggested_score_team_2"]
+              )}
+            >
+              <p class="mb-3 mr-2 rounded bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900 dark:text-red-300">
+                Scores Clashing
+              </p>
+            </Show>
+            <Show when={props.match[`suggested_score_team_${currTeamNo()}`]}>
+              <p class="mb-2 w-full text-center text-sm">
+                {
+                  props.match[`suggested_score_team_${currTeamNo()}`][
+                    "entered_by"
+                  ]["user_first_name"]
+                }
+                {" | "}
+                {props.match[`team_${currTeamNo()}`].name}
+                {": "}
+                {
+                  props.match[`suggested_score_team_${currTeamNo()}`][
+                    `score_team_${currTeamNo()}`
+                  ]
+                }{" "}
+                -{" "}
+                {
+                  props.match[`suggested_score_team_${currTeamNo()}`][
+                    `score_team_${oppTeamNo()}`
+                  ]
+                }{" "}
+              </p>
+            </Show>
+            <Show when={props.match[`suggested_score_team_${oppTeamNo()}`]}>
+              <p class="mb-2 w-full text-center text-sm">
+                {
+                  props.match[`suggested_score_team_${oppTeamNo()}`][
+                    "entered_by"
+                  ]["user_first_name"]
+                }
+                {" | "}
+                {props.match[`team_${oppTeamNo()}`].name}
+                {": "}
+                {
+                  props.match[`suggested_score_team_${oppTeamNo()}`][
+                    `score_team_${currTeamNo()}`
+                  ]
+                }{" "}
+                -{" "}
+                {
+                  props.match[`suggested_score_team_${oppTeamNo()}`][
+                    `score_team_${oppTeamNo()}`
+                  ]
+                }{" "}
+              </p>
+            </Show>
+            <Show
+              when={
+                isStaff() &&
+                !isMatchTeamAdmin() &&
+                !props.match[`suggested_score_team_${currTeamNo()}`] &&
+                !props.match[`suggested_score_team_${oppTeamNo()}`]
               }
-              {" | "}
-              {props.match[`team_${currTeamNo()}`].name}
-              {": "}
-              {
-                props.match[`suggested_score_team_${currTeamNo()}`][
-                  `score_team_${currTeamNo()}`
-                ]
-              }{" "}
-              -{" "}
-              {
-                props.match[`suggested_score_team_${currTeamNo()}`][
-                  `score_team_${oppTeamNo()}`
-                ]
-              }{" "}
+            >
+              <p class="text-center text-sm">No scores have been submitted yet</p>
+            </Show>
+            <Show when={isMatchTeamAdmin()}>
+              <SubmitScore
+                buttonColor={
+                  props.buttonColor
+                    ? matchCardColorToButtonStyles[props.buttonColor]
+                    : matchCardColorToButtonStyles[getMatchCardColor(props.match)]
+                }
+                button={
+                  hasUserNotSubmittedScores()
+                    ? { text: "Submit Score", icon: arrowRight }
+                    : { text: "Edit Score", icon: pencil }
+                }
+                onClose={() => {
+                  queryClient.invalidateQueries({
+                    queryKey: ["matches", props.tournamentSlug]
+                  });
+                  queryClient.invalidateQueries({
+                    queryKey: ["team-matches", props.tournamentSlug]
+                  });
+                }}
+              >
+                <div class="rounded-lg bg-white p-4 shadow dark:bg-gray-700">
+                  <MatchScoreForm
+                    match={props.match}
+                    currTeamNo={currTeamNo()}
+                    oppTeamNo={oppTeamNo()}
+                  />
+                </div>
+              </SubmitScore>
+            </Show>
+          </div>
+        </Show> */}
+        {/* Spirit score pending */}
+        {/* <Show
+          when={
+            (props.match.status === "completed" || props.match.status === "scheduled") &&
+            isStaff() &&
+            (!props.match["spirit_score_team_2"] ||
+              !props.match["spirit_score_team_1"])
+          }
+        >
+          <div class="inline-flex w-full items-center justify-center">
+            <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
+            <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
+              Spirit Scores
+            </span>
+          </div>
+          <Show when={!props.match[`spirit_score_team_${oppTeamNo()}`]}>
+            <p class="text-center text-sm">
+              {props.match[`team_${currTeamNo()}`].name} pending
             </p>
           </Show>
-          <Show when={props.match[`suggested_score_team_${oppTeamNo()}`]}>
-            <p class="mb-2 w-full text-center text-sm">
-              {
-                props.match[`suggested_score_team_${oppTeamNo()}`][
-                  "entered_by"
-                ]["user_first_name"]
-              }
-              {" | "}
-              {props.match[`team_${oppTeamNo()}`].name}
-              {": "}
-              {
-                props.match[`suggested_score_team_${oppTeamNo()}`][
-                  `score_team_${currTeamNo()}`
-                ]
-              }{" "}
-              -{" "}
-              {
-                props.match[`suggested_score_team_${oppTeamNo()}`][
-                  `score_team_${oppTeamNo()}`
-                ]
-              }{" "}
+          <Show when={!props.match[`spirit_score_team_${currTeamNo()}`]}>
+            <p class="text-center text-sm">
+              {props.match[`team_${oppTeamNo()}`].name} pending
             </p>
           </Show>
-          <Show
-            when={
-              isStaff() &&
-              !isMatchTeamAdmin() &&
-              !props.match[`suggested_score_team_${currTeamNo()}`] &&
-              !props.match[`suggested_score_team_${oppTeamNo()}`]
-            }
-          >
-            <p class="text-center text-sm">No scores have been submitted yet</p>
-          </Show>
-
-          <Show when={isMatchTeamAdmin()}>
-            <SubmitScore
+        </Show> */}
+        {/* Spirit Score submit */}
+        {/* <Show
+          when={
+            (props.match.status === "completed" || props.match.status === "scheduled") &&
+            isMatchTeamAdmin() &&
+            canUserSubmitSpiritScores()
+          }
+        >
+          <div class="inline-flex w-full items-center justify-center">
+            <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
+            <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
+              Spirit Scores
+            </span>
+          </div>
+          <div class="mb-3 flex flex-wrap justify-center">
+            <SubmitSpiritScore
               buttonColor={
                 props.buttonColor
                   ? matchCardColorToButtonStyles[props.buttonColor]
                   : matchCardColorToButtonStyles[getMatchCardColor(props.match)]
-              }
-              button={
-                hasUserNotSubmittedScores()
-                  ? { text: "Submit Score", icon: arrowRight }
-                  : { text: "Edit Score", icon: pencil }
               }
               onClose={() => {
                 queryClient.invalidateQueries({
@@ -768,127 +879,58 @@ const TournamentMatch = props => {
                 });
               }}
             >
-              <div class="rounded-lg bg-white p-4 shadow dark:bg-gray-700">
-                <MatchScoreForm
+              <Show when={isTeamAdminOf(props.match["team_1"].id)}>
+                <MatchSpiritScoreForm
                   match={props.match}
-                  currTeamNo={currTeamNo()}
-                  oppTeamNo={oppTeamNo()}
+                  tournamentSlug={props.tournamentSlug}
+                  oppTeamNo={2}
+                  curTeamNo={1}
                 />
-              </div>
-            </SubmitScore>
-          </Show>
-        </div>
-      </Show>
-
-      {/* Spirit score pending */}
-      {/* <Show
-        when={
-          (props.match.status === "completed" || props.match.status === "scheduled") &&
-          isStaff() &&
-          (!props.match["spirit_score_team_2"] ||
-            !props.match["spirit_score_team_1"])
-        }
-      >
-        <div class="inline-flex w-full items-center justify-center">
-          <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
-          <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
-            Spirit Scores
-          </span>
-        </div>
-        <Show when={!props.match[`spirit_score_team_${oppTeamNo()}`]}>
-          <p class="text-center text-sm">
-            {props.match[`team_${currTeamNo()}`].name} pending
-          </p>
-        </Show>
-        <Show when={!props.match[`spirit_score_team_${currTeamNo()}`]}>
-          <p class="text-center text-sm">
-            {props.match[`team_${oppTeamNo()}`].name} pending
-          </p>
-        </Show>
-      </Show> */}
-
-      {/* Spirit Score submit */}
-      {/* <Show
-        when={
-          (props.match.status === "completed" || props.match.status === "scheduled") &&
-          isMatchTeamAdmin() &&
-          canUserSubmitSpiritScores()
-        }
-      >
-        <div class="inline-flex w-full items-center justify-center">
-          <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
-          <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
-            Spirit Scores
-          </span>
-        </div>
-        <div class="mb-3 flex flex-wrap justify-center">
-          <SubmitSpiritScore
-            buttonColor={
-              props.buttonColor
-                ? matchCardColorToButtonStyles[props.buttonColor]
-                : matchCardColorToButtonStyles[getMatchCardColor(props.match)]
-            }
-            onClose={() => {
-              queryClient.invalidateQueries({
-                queryKey: ["matches", props.tournamentSlug]
-              });
-              queryClient.invalidateQueries({
-                queryKey: ["team-matches", props.tournamentSlug]
-              });
-            }}
-          >
-            <Show when={isTeamAdminOf(props.match["team_1"].id)}>
-              <MatchSpiritScoreForm
-                match={props.match}
-                tournamentSlug={props.tournamentSlug}
-                oppTeamNo={2}
-                curTeamNo={1}
-              />
-            </Show>
-            <Show when={isTeamAdminOf(props.match["team_2"].id)}>
-              <MatchSpiritScoreForm
-                match={props.match}
-                tournamentSlug={props.tournamentSlug}
-                oppTeamNo={1}
-                curTeamNo={2}
-              />
-            </Show>
-          </SubmitSpiritScore>
-        </div>
-      </Show> */}
-
-      {/* <Show
-        when={
-          (props.match.status === "COM" || props.match.status === "SCH") &&
-          isStaff()
-        }
-      >
-        <div class="inline-flex w-full items-center justify-center">
-          <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
-          <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
-            Stats
-          </span>
-        </div>
-        <div class="flex flex-wrap justify-center">
-          <Show
-            when={props.match?.stats}
-            fallback={
-              <CreateStatsButton
-                match={props.match}
-                tournamentSlug={props.tournamentSlug}
-              />
-            }
-          >
-            <A
-              class="rounded-lg bg-blue-500 px-2 py-1 text-white"
-              href={`/tournament/${props.tournamentSlug}/match/${props.match?.id}/edit-stats-min`}
+              </Show>
+              <Show when={isTeamAdminOf(props.match["team_2"].id)}>
+                <MatchSpiritScoreForm
+                  match={props.match}
+                  tournamentSlug={props.tournamentSlug}
+                  oppTeamNo={1}
+                  curTeamNo={2}
+                />
+              </Show>
+            </SubmitSpiritScore>
+          </div>
+        </Show> */}
+        {/* <Show
+          when={
+            (props.match.status === "COM" || props.match.status === "SCH") &&
+            isStaff()
+          }
+        >
+          <div class="inline-flex w-full items-center justify-center">
+            <hr class="my-6 h-px w-64 border-0 bg-gray-200 dark:bg-gray-700" />
+            <span class="absolute left-1/2 -translate-x-1/2 bg-white px-3 text-sm dark:bg-gray-800">
+              Stats
+            </span>
+          </div>
+          <div class="flex flex-wrap justify-center">
+            <Show
+              when={props.match?.stats}
+              fallback={
+                <CreateStatsButton
+                  match={props.match}
+                  tournamentSlug={props.tournamentSlug}
+                />
+              }
             >
-              Edit Stats
-            </A>
-          </Show>
-        </div>
-      </Show> */}
-    </>
+              <A
+                class="rounded-lg bg-blue-500 px-2 py-1 text-white"
+                href={`/tournament/${props.tournamentSlug}/match/${props.match?.id}/edit-stats-min`}
+              >
+                Edit Stats
+              </A>
+            </Show>
+          </div>
+        </Show> */}
+      </div>
+    </A>
   );
 };
 

--- a/frontend/src/components/match/MatchGallery.jsx
+++ b/frontend/src/components/match/MatchGallery.jsx
@@ -1,0 +1,3 @@
+const MatchGallery = () => <div>Match gallery here</div>
+
+export default MatchGallery

--- a/frontend/src/components/match/MatchMvpMsp.jsx
+++ b/frontend/src/components/match/MatchMvpMsp.jsx
@@ -1,0 +1,3 @@
+const MatchMvpMsp = () => <div>Match mvp msp details here</div>
+
+export default MatchMvpMsp

--- a/frontend/src/components/match/MatchTimeline.jsx
+++ b/frontend/src/components/match/MatchTimeline.jsx
@@ -1,0 +1,5 @@
+const MatchTimeline = () => {
+    return <div>Match timeline here</div>
+}
+
+export default MatchTimeline;

--- a/frontend/src/pages/MatchDetails.jsx
+++ b/frontend/src/pages/MatchDetails.jsx
@@ -1,0 +1,285 @@
+import { useQuery } from "@tanstack/solid-query";
+import { fetchMatch } from "~/queries";
+import { useParams, A } from "@solidjs/router";
+
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator
+} from "~/components/ui/breadcrumb";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
+
+import clsx from "clsx";
+import { Separator } from "~/components/ui/separator";
+import { createEffect, createSignal, Match, Switch } from "solid-js";
+
+import MatchTimeline from "~/components/match/MatchTimeline";
+import MatchGallery from "~/components/match/MatchGallery";
+import MatchMvpMsp from "~/components/match/MatchMvpMsp";
+
+const MatchDetails = () => {
+  const params = useParams();
+  const [startTime, setStartTime] = createSignal();
+  const [endTime, setEndTime] = createSignal();
+  const [isMatchLive, setIsMatchLive] = createSignal(false);
+
+  const matchQuery = useQuery(() => ({
+    queryKey: ["match", params.match_id],
+    queryFn: () => fetchMatch(params.match_id)
+  }));
+
+  createEffect(() => {
+    if (matchQuery.isSuccess) {
+      const startTimeObject = new Date(Date.parse(matchQuery.data?.time));
+      const endTimeObject = new Date(
+        startTimeObject.getTime() + matchQuery.data?.duration_mins * 60000
+      );
+
+      setStartTime(
+        startTimeObject.toLocaleTimeString("en-US", {
+          hour: "numeric",
+          minute: "numeric",
+          timeZone: "UTC"
+        })
+      );
+      setEndTime(
+        endTimeObject.toLocaleTimeString("en-US", {
+          hour: "numeric",
+          minute: "numeric",
+          timeZone: "UTC"
+        })
+      );
+
+      const currTime = new Date(Date.now()).toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "numeric",
+        timeZone: "UTC"
+      });
+
+      setIsMatchLive(startTime() <= currTime && currTime <= endTime());
+    }
+  });
+
+  return (
+    <div class="max-w-2xl px-1 sm:mx-auto">
+      <div class="mb-3 mt-4 flex w-full items-center justify-between ">
+        <Breadcrumb class="">
+          <BreadcrumbList>
+            <BreadcrumbEllipsis class="h-fit w-fit rounded-xl border border-gray-400 px-2 py-0.5" />
+            <BreadcrumbSeparator class="mx-1" />
+            <BreadcrumbItem>
+              <BreadcrumbLink
+                href={`/tournament/${params.tournament_slug}/schedule`}
+              >
+                <span class="rounded-xl border border-gray-400 px-2 py-0.5 text-sm">
+                  Schedule
+                </span>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+
+            <BreadcrumbSeparator class="mx-1" />
+
+            <BreadcrumbItem>
+              <BreadcrumbLink current>
+                <span class="rounded-xl border border-gray-400 px-2 py-0.5 text-sm">
+                  {matchQuery.data?.name}
+                </span>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
+        {/* Match status badge */}
+        <div>
+          <Switch>
+            <Match when={matchQuery.data?.status === "completed"}>
+              <div class="rounded-xl bg-gray-200 px-3 py-0.5 sm:py-0 text-gray-800 outline outline-1 outline-gray-400 text-sm sm:text-base">
+                Completed
+              </div>
+            </Match>
+            <Match when={matchQuery.data?.status === "scheduled"}>
+              <div class="rounded-xl bg-blue-200 px-3 py-0.5 sm:py-0 text-blue-800 outline outline-1 outline-blue-400 text-sm sm:text-base">
+                Upcoming
+              </div>
+            </Match>
+            <Match
+              when={isMatchLive()}
+            >
+              <div class="flex items-center justify-between gap-2 rounded-xl bg-red-100 px-3 py-0.5 text-sm text-red-600 outline outline-1 outline-red-400 sm:py-0 sm:text-base">
+                <span class="relative flex size-2">
+                  <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75"></span>
+                  <span class="relative inline-flex size-2 rounded-full bg-red-500"></span>
+                </span>
+                <span>Live</span>
+              </div>
+            </Match>
+          </Switch>
+        </div>
+      </div>
+
+      <Separator class="mb-2 mt-4" />
+
+      <div class="mt-4 flex flex-col gap-4 px-1">
+        {/* Team 1 */}
+        <div class="flex w-full items-center justify-between text-lg">
+          <div>
+            <Show
+              when={matchQuery.data?.team_1}
+              fallback={
+                <span class="w-1/3 text-center font-bold">
+                  {matchQuery.data?.placeholder_seed_1}
+                </span>
+              }
+            >
+              <img
+                class={clsx(
+                  "mr-2 inline-block h-6 w-6 rounded-full object-cover p-1 ring-1 ring-gray-400"
+                )}
+                src={matchQuery.data?.team_1?.logo}
+                alt="Bordered avatar"
+              />
+              <span class="w-1/3 text-center font-bold text-gray-600 dark:text-gray-300">
+                <A
+                  href={`/tournament/${params.tournament_slug}/team/${
+                    matchQuery.data?.team_1.slug
+                  }`}
+                >
+                  {matchQuery.data?.team_1.name} [
+                  {matchQuery.data?.placeholder_seed_1}]
+                </A>
+              </span>
+            </Show>
+          </div>
+          <div class="text-xl font-bold">
+            <Show when={matchQuery.data?.status === "completed"}>
+              <Switch>
+                <Match
+                  when={
+                    matchQuery.data?.score_team_1 >
+                    matchQuery.data?.score_team_2
+                  }
+                >
+                  <span class="text-green-500">
+                    {matchQuery.data?.score_team_1}
+                  </span>
+                </Match>
+                <Match
+                  when={
+                    matchQuery.data?.score_team_1 <
+                    matchQuery.data?.score_team_2
+                  }
+                >
+                  <span class="text-red-500">
+                    {matchQuery.data?.score_team_1}
+                  </span>
+                </Match>
+                <Match
+                  when={
+                    matchQuery.data?.score_team_1 ===
+                    matchQuery.data?.score_team_2
+                  }
+                >
+                  <span class="text-blue-500">
+                    {matchQuery.data?.score_team_1}
+                  </span>
+                </Match>
+              </Switch>
+            </Show>
+          </div>
+        </div>
+
+        {/* Team 2 */}
+        <div class="flex w-full items-center justify-between text-lg">
+          <div>
+            <Show
+              when={matchQuery.data?.team_2}
+              fallback={
+                <span class="w-1/3 text-center font-bold">
+                  {matchQuery.data?.placeholder_seed_2}
+                </span>
+              }
+            >
+              <img
+                class={clsx(
+                  "mr-2 inline-block h-6 w-6 rounded-full object-cover p-1 ring-1 ring-gray-400"
+                )}
+                src={matchQuery.data?.team_2?.logo}
+                alt="Bordered avatar"
+              />
+              <span class="w-1/3 text-center font-bold text-gray-600 dark:text-gray-300">
+                <A
+                  href={`/tournament/${params.tournament_slug}/team/${
+                    matchQuery.data?.team_2.slug
+                  }`}
+                >
+                  {matchQuery.data?.team_2.name} [
+                  {matchQuery.data?.placeholder_seed_2}]
+                </A>
+              </span>
+            </Show>
+          </div>
+          <div class="text-xl font-bold">
+            <Show when={matchQuery.data?.status === "completed"}>
+              <Switch>
+                <Match
+                  when={
+                    matchQuery.data?.score_team_1 >
+                    matchQuery.data?.score_team_2
+                  }
+                >
+                  <span class="text-red-500">
+                    {matchQuery.data?.score_team_2}
+                  </span>
+                </Match>
+                <Match
+                  when={
+                    matchQuery.data?.score_team_1 <
+                    matchQuery.data?.score_team_2
+                  }
+                >
+                  <span class="text-green-500">
+                    {matchQuery.data?.score_team_2}
+                  </span>
+                </Match>
+                <Match
+                  when={
+                    matchQuery.data?.score_team_1 ===
+                    matchQuery.data?.score_team_2
+                  }
+                >
+                  <span class="text-blue-500">
+                    {matchQuery.data?.score_team_2}
+                  </span>
+                </Match>
+              </Switch>
+            </Show>
+          </div>
+        </div>
+      </div>
+
+      <Separator class="mb-2 mt-4" />
+
+      <Tabs>
+        <TabsList defaultValue="timeline-tab" class="mt-2">
+          <TabsTrigger value="timeline-tab">Timeline</TabsTrigger>
+          <TabsTrigger value="mvp-msp-tab">MVP/MSP</TabsTrigger>
+          <TabsTrigger value="gallery-tab">Gallery</TabsTrigger>
+        </TabsList>
+        <TabsContent value="timeline-tab">
+          <MatchTimeline match={matchQuery.data} />
+        </TabsContent>
+        <TabsContent value="mvp-msp-tab">
+            <MatchMvpMsp match={matchQuery.data}/>
+        </TabsContent>
+        <TabsContent value="gallery-tab">
+            <MatchGallery match={matchQuery.data} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default MatchDetails;

--- a/frontend/src/pages/TournamentSchedule.jsx
+++ b/frontend/src/pages/TournamentSchedule.jsx
@@ -65,28 +65,12 @@ const TournamentSchedule = () => {
     enabled: !!tournamentQuery.data?.id
   }));
 
-  function sameDay(dayString, d2) {
-    const d2String = d2.toLocaleDateString("en-US", {
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      timeZone: "UTC"
-    });
-
-    const pattern =
-      /^(?<day>\w+), (?<month>\w+) (?<date>\d{1,2}), (?<year>\d{4})$/;
-    const dayStringMatch = dayString.match(pattern);
-    const d2StringMatch = d2String.match(pattern);
-
-    if (dayStringMatch && d2StringMatch) {
-      return (
-        dayStringMatch.groups.year === d2StringMatch.groups.year &&
-        dayStringMatch.groups.month === d2StringMatch.groups.month &&
-        dayStringMatch.groups.date === d2StringMatch.groups.date
-      );
-    }
-    return false;
+  function sameDay(d1, d2) {
+    return (
+      d1.getUTCFullYear() === d2.getUTCFullYear() &&
+      d1.getUTCMonth() === d2.getUTCMonth() &&
+      d1.getUTCDate() === d2.getUTCDate()
+    );
   }
 
   const mapFieldIdToField = fields => {
@@ -107,14 +91,12 @@ const TournamentSchedule = () => {
           const day = new Date(Date.parse(match.time)).toLocaleDateString(
             "en-US",
             {
-              weekday: "long",
               year: "numeric",
-              month: "long",
+              month: "short",
               day: "numeric",
               timeZone: "UTC"
             }
           );
-
           const startTime = new Date(Date.parse(match.time));
           const endTime = new Date(
             startTime.getTime() + match.duration_mins * 60000
@@ -133,7 +115,7 @@ const TournamentSchedule = () => {
           setDayFieldMap(day, {});
           setDayFieldMap(day, match.field?.id, true);
 
-          days.add(day);
+          days.add(new Date(Date.parse(match.time)));
         }
       });
       setTournamentDays(Array.from(days));
@@ -267,7 +249,13 @@ const TournamentSchedule = () => {
                           class="text-sm md:text-base"
                           value={"day-tab-" + (i() + 1)}
                         >
-                          {day}
+                          {day.toLocaleDateString("en-US", {
+                            weekday: "long",
+                            year: "numeric",
+                            month: "long",
+                            day: "numeric",
+                            timeZone: "UTC"
+                          })}
                         </TabsTrigger>
                       )}
                     </For>

--- a/frontend/src/pages/TournamentSchedule.jsx
+++ b/frontend/src/pages/TournamentSchedule.jsx
@@ -338,41 +338,31 @@ const TournamentSchedule = () => {
                     // fallback={<TournamentMatchesSkeleton />}
                     fallback={"Loading matches..."}
                   > */}
-                          <For each={matchesQuery.data}>
-                            {match => (
-                              <Show
-                                when={sameDay(
-                                  day,
-                                  new Date(Date.parse(match.time))
-                                )}
-                              >
-                                <div
-                                  id={match.id}
-                                  class={clsx(
-                                    flash() == match.id
-                                      ? "bg-blue-100 text-black dark:bg-slate-700 dark:text-white"
-                                      : "bg-white dark:bg-gray-800",
-                                    "mb-5 block w-full rounded-lg border px-1 py-2 shadow transition",
-                                    matchCardColorToBorderColorMap[
-                                      getMatchCardColor(match)
-                                    ]
-                                  )}
-                                >
-                                  <MatchCard
-                                    match={match}
-                                    tournamentSlug={params.slug}
-                                    bothTeamsClickable
-                                  />
-                                </div>
-                              </Show>
+                    <For each={matchesQuery.data}>
+                      {match => (
+                        <Show
+                          when={sameDay(day, new Date(Date.parse(match.time)))}
+                        >
+                          <div
+                            id={match.id}
+                            class={clsx(
+                              flash() == match.id
+                                ? "bg-blue-100 text-black"
+                                : "bg-white",
+                              "mb-5 block w-full rounded-lg border border-gray-400 px-1 py-2 transition shadow-sm",
                             )}
-                          </For>
-                          {/* </Suspense> */}
-                        </div>
-                      </TabsContent>
-                    )}
-                  </For>
-                </Tabs>
+                          >
+                            <MatchCard
+                              match={match}
+                              tournamentSlug={params.slug}
+                              bothTeamsClickable
+                            />
+                          </div>
+                        </Show>
+                      )}
+                    </For>
+                  {/* </Suspense> */}
+                </div>
               </TabsContent>
             )}
           </For>

--- a/frontend/src/pages/TournamentSchedule.jsx
+++ b/frontend/src/pages/TournamentSchedule.jsx
@@ -65,12 +65,28 @@ const TournamentSchedule = () => {
     enabled: !!tournamentQuery.data?.id
   }));
 
-  function sameDay(d1, d2) {
-    return (
-      d1.getUTCFullYear() === d2.getUTCFullYear() &&
-      d1.getUTCMonth() === d2.getUTCMonth() &&
-      d1.getUTCDate() === d2.getUTCDate()
-    );
+  function sameDay(dayString, d2) {
+    const d2String = d2.toLocaleDateString("en-US", {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC"
+    });
+
+    const pattern =
+      /^(?<day>\w+), (?<month>\w+) (?<date>\d{1,2}), (?<year>\d{4})$/;
+    const dayStringMatch = dayString.match(pattern);
+    const d2StringMatch = d2String.match(pattern);
+
+    if (dayStringMatch && d2StringMatch) {
+      return (
+        dayStringMatch.groups.year === d2StringMatch.groups.year &&
+        dayStringMatch.groups.month === d2StringMatch.groups.month &&
+        dayStringMatch.groups.date === d2StringMatch.groups.date
+      );
+    }
+    return false;
   }
 
   const mapFieldIdToField = fields => {
@@ -91,12 +107,14 @@ const TournamentSchedule = () => {
           const day = new Date(Date.parse(match.time)).toLocaleDateString(
             "en-US",
             {
+              weekday: "long",
               year: "numeric",
-              month: "short",
+              month: "long",
               day: "numeric",
               timeZone: "UTC"
             }
           );
+
           const startTime = new Date(Date.parse(match.time));
           const endTime = new Date(
             startTime.getTime() + match.duration_mins * 60000
@@ -115,7 +133,7 @@ const TournamentSchedule = () => {
           setDayFieldMap(day, {});
           setDayFieldMap(day, match.field?.id, true);
 
-          days.add(new Date(Date.parse(match.time)));
+          days.add(day);
         }
       });
       setTournamentDays(Array.from(days));
@@ -249,13 +267,7 @@ const TournamentSchedule = () => {
                           class="text-sm md:text-base"
                           value={"day-tab-" + (i() + 1)}
                         >
-                          {day.toLocaleDateString("en-US", {
-                            weekday: "long",
-                            year: "numeric",
-                            month: "long",
-                            day: "numeric",
-                            timeZone: "UTC"
-                          })}
+                          {day}
                         </TabsTrigger>
                       )}
                     </For>

--- a/frontend/src/pages/TournamentSchedule.jsx
+++ b/frontend/src/pages/TournamentSchedule.jsx
@@ -220,8 +220,6 @@ const TournamentSchedule = () => {
           </BreadcrumbList>
         </Breadcrumb>
 
-       
-
         <Tabs defaultValue="week-tab-week-1" class="mt-2 w-full">
           <TabsList class="grid w-full grid-cols-4">
             <For each={weeks()}>
@@ -268,10 +266,10 @@ const TournamentSchedule = () => {
                       <TabsContent value={"day-tab-" + (i() + 1)}>
                         <div class="rounded-lg">
                           {/* <Show
-                    when={doneBuildingScheduleMap()}
-                    // fallback={<DayScheduleSkeleton />}
-                    fallback={"Loading Schedule..."}
-                  /> */}
+                            when={doneBuildingScheduleMap()}
+                            // fallback={<DayScheduleSkeleton />}
+                            fallback={"Loading Schedule..."}
+                          /> */}
                           <For each={Object.keys(matchDayTimeFieldMap).sort()}>
                             {day2 => (
                               <Show
@@ -335,34 +333,41 @@ const TournamentSchedule = () => {
                             </div>
                           </Show>
                           {/* <Suspense
-                    // fallback={<TournamentMatchesSkeleton />}
-                    fallback={"Loading matches..."}
-                  > */}
-                    <For each={matchesQuery.data}>
-                      {match => (
-                        <Show
-                          when={sameDay(day, new Date(Date.parse(match.time)))}
-                        >
-                          <div
-                            id={match.id}
-                            class={clsx(
-                              flash() == match.id
-                                ? "bg-blue-100 text-black"
-                                : "bg-white",
-                              "mb-5 block w-full rounded-lg border border-gray-400 px-1 py-2 transition shadow-sm",
+                            // fallback={<TournamentMatchesSkeleton />}
+                            fallback={"Loading matches..."}
+                          > */}
+                          <For each={matchesQuery.data}>
+                            {match => (
+                              <Show
+                                when={sameDay(
+                                  day,
+                                  new Date(Date.parse(match.time))
+                                )}
+                              >
+                                <div
+                                  id={match.id}
+                                  class={clsx(
+                                    flash() == match.id
+                                      ? "bg-blue-100 text-black"
+                                      : "bg-white",
+                                    "mb-5 block w-full rounded-lg border border-gray-400 px-1 py-2 shadow-sm transition"
+                                  )}
+                                >
+                                  <MatchCard
+                                    match={match}
+                                    tournamentSlug={params.slug}
+                                    bothTeamsClickable
+                                  />
+                                </div>
+                              </Show>
                             )}
-                          >
-                            <MatchCard
-                              match={match}
-                              tournamentSlug={params.slug}
-                              bothTeamsClickable
-                            />
-                          </div>
-                        </Show>
-                      )}
-                    </For>
-                  {/* </Suspense> */}
-                </div>
+                          </For>
+                          {/* </Suspense> */}
+                        </div>
+                      </TabsContent>
+                    )}
+                  </For>
+                </Tabs>
               </TabsContent>
             )}
           </For>

--- a/frontend/src/pages/TournamentTeam.jsx
+++ b/frontend/src/pages/TournamentTeam.jsx
@@ -207,7 +207,7 @@ const TournamentTeam = () => {
           </TabsList>
 
           <TabsContent value="matches-tab">
-            <div class="mt-4">
+            <div class="mt-4 p-4">
               <For each={Object.entries(matchesGroupedByDate())}>
                 {([tournamentDate, matches]) => (
                   <div class="mb-10">

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -147,6 +147,16 @@ export const fetchMatches = async tournamentId => {
 };
 
 /**
+ * Fetch particular match by ID
+ * @param {number} matchId
+ * @returns {Object} - Match with all its details
+ */
+
+export const fetchMatch = async matchId => {
+  return apiRequest(`/api/matches/${matchId}`, "GET");
+};
+
+/**
  * Fetch all matches for a team in a tournament
  * @param {number} tournamentSlug - Tournament Slug
  * @param {number} teamSlug - Team Slug

--- a/osu/match/schema.py
+++ b/osu/match/schema.py
@@ -75,12 +75,12 @@ class MatchBasicSchema(ModelSchema):
     cross_pool: CrossPoolSchema | None
     bracket: BracketSchema | None
     position_pool: PositionPoolSchema | None
-    suggested_score_team_1: MatchScoreSchema | None = None
-    suggested_score_team_2: MatchScoreSchema | None = None
-    spirit_score_team_1: SpiritScoreSchema | None = None
-    spirit_score_team_2: SpiritScoreSchema | None = None
-    self_spirit_score_team_1: SpiritScoreSchema | None = None
-    self_spirit_score_team_2: SpiritScoreSchema | None = None
+    # suggested_score_team_1: MatchScoreSchema | None = None
+    # suggested_score_team_2: MatchScoreSchema | None = None
+    # spirit_score_team_1: SpiritScoreSchema | None = None
+    # spirit_score_team_2: SpiritScoreSchema | None = None
+    # self_spirit_score_team_1: SpiritScoreSchema | None = None
+    # self_spirit_score_team_2: SpiritScoreSchema | None = None
 
     class Config:
         model = Match
@@ -105,6 +105,10 @@ class MatchBasicSchema(ModelSchema):
 
 
 class MatchDetailSchema(MatchBasicSchema):
+    team_1: TeamBasicSchema
+    team_2: TeamBasicSchema
+    tournament: TournamentBasicSchema
+    field: TournamentFieldSchema | None = None
     placeholder_seed_1: int
     placeholder_seed_2: int
     created_at: datetime
@@ -115,6 +119,20 @@ class MatchDetailSchema(MatchBasicSchema):
     spirit_score_team_2: SpiritScoreSchema | None = None
     self_spirit_score_team_1: SpiritScoreSchema | None = None
     self_spirit_score_team_2: SpiritScoreSchema | None = None
+
+    class Config:
+        model = Match
+        model_fields = [
+            "id",
+            "name",
+            "time",
+            "duration_mins",
+            "score_team_1",
+            "score_team_2",
+            "status",
+            "video_url",
+            "sequence_number",
+        ]
 
 
 # Input schemas


### PR DESCRIPTION
Doing the match details page tabs (stats view, submit scores to be moved and gallery) in a different tab, so its easy to review

Match card redesign
![image](https://github.com/user-attachments/assets/de24ee08-cb12-4275-9a05-643ac1afc500)

Match details page layout
![image](https://github.com/user-attachments/assets/b4dcbdd0-495a-4bea-b420-a9df5f8a9b5b)
